### PR TITLE
fix(boolean property comment):  Comment field is always enabled

### DIFF
--- a/apps/dsp-app/src/app/workspace/resource/values/boolean-value/boolean-value.component.html
+++ b/apps/dsp-app/src/app/workspace/resource/values/boolean-value/boolean-value.component.html
@@ -55,7 +55,7 @@
         <app-comment-form
             [valueFormControlHasError]="hasError()"
             [(commentFormControl)]="commentFormControl"
-            [valueFormControlValue]="valueFormControl.value"
+            [valueFormControlValue]="valueFormControl.value.toString()"
         ></app-comment-form>
     </span>
 </ng-template>


### PR DESCRIPTION
For boolean properties(no invalid state for booleans), the comment field is always enabled.

resolves DEV-2167
