### PR TITLE
fix (richtext component): Text is selectable

### DIFF
--- a/apps/dsp-app/src/app/workspace/resource/directives/text-value-html-link.directive.spec.ts
+++ b/apps/dsp-app/src/app/workspace/resource/directives/text-value-html-link.directive.spec.ts
@@ -65,51 +65,72 @@ describe('TextValueHtmlLinkDirective', () => {
         expect(testHostComponent).toBeTruthy();
     });
 
-    it('should emit a left mouse button click on an internal link', () => {
+    it('should emit a left mouse click on an internal link', () => {
 
-        expect(testHostComponent).toBeTruthy();
-        expect(testHostComponent.internalLinkClickedIri).toBeUndefined();
+        // fake the link element
+        const fakeEventTarget = {
+            nodeName: 'A',
+            className: 'salsah-link',
+            href: 'http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw'
+        };
 
-        const hostCompDe = testHostFixture.debugElement;
-        const directiveDe = hostCompDe.query(
-            By.directive(TextValueHtmlLinkDirective)
-        );
+        // fake a left mouse click
+        const fakeEvent = {
+            target: fakeEventTarget,
+            button: 0, // left mouse button
+            preventDefault: jasmine.createSpy('preventDefault')
+        };
 
-        const internalLinkDe = directiveDe.query(By.css('a.salsah-link'));
+        // Create a spy on the emit method
+        spyOn(directive.internalLinkClicked, 'emit');
 
-        // left mouse event
-        internalLinkDe.nativeElement.dispatchEvent(
-            new MouseEvent('mousedown', { bubbles: true, button: 0 })
-    );
+        // Call the onClick method directly with the fake event without using/testing the @HostListener decorator
+        // or outputs
+        directive.onClick(fakeEvent as any);
 
-        testHostFixture.detectChanges();
+        // Check if emit was called
+        expect(directive.internalLinkClicked.emit).toHaveBeenCalled();
 
-        expect(testHostComponent.internalLinkClickedIri).toEqual(
-            'http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw'
-        );
+        // check the value; no need to test Angular EventEmitter
+        expect(directive.internalLinkClicked.emit).toHaveBeenCalledWith('http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw');
+
+        // Check if the default action (i.e. window open of 'http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw') was prevented.
+        // This must happen in case of an internal link.
+        expect(fakeEvent.preventDefault).toHaveBeenCalled();
     });
 
-    it('should emit a right mouse button click on an internal link', () => {
-        expect(testHostComponent).toBeTruthy();
-        expect(testHostComponent.internalLinkClickedIri).toBeUndefined();
+    it('should emit right mouse down on an internal link', () => {
 
-        const hostCompDe = testHostFixture.debugElement;
-        const directiveDe = hostCompDe.query(
-            By.directive(TextValueHtmlLinkDirective)
-        );
+        // fake the link element
+        const fakeEventTarget = {
+            nodeName: 'A',
+            className: 'salsah-link',
+            href: 'http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw'
+        };
 
-        const internalLinkDe = directiveDe.query(By.css('a.salsah-link'));
+        // fake a left mouse down event
+        const fakeMouseDownEvent = {
+            target: fakeEventTarget,
+            button: 2, // left mouse button
+            preventDefault: jasmine.createSpy('preventDefault')
+        };
 
-        // left mouse event
-        internalLinkDe.nativeElement.dispatchEvent(
-            new MouseEvent('mousedown', { bubbles: true, button: 2 })
-        );
+        // Create a spy on the emit method
+        spyOn(directive.internalLinkClicked, 'emit');
 
-        testHostFixture.detectChanges();
+        // Call the onClick method directly with the fake event without using/testing the @HostListener decorator
+        // or outputs
+        directive.onMouseDown(fakeMouseDownEvent as any);
 
-        expect(testHostComponent.internalLinkClickedIri).toEqual(
-            'http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw'
-        );
+        // Check if emit was called
+        expect(directive.internalLinkClicked.emit).toHaveBeenCalled();
+
+        // check the value; no need to test Angular EventEmitter
+        expect(directive.internalLinkClicked.emit).toHaveBeenCalledWith('http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw');
+
+        // Check if the default action (i.e. window open of 'http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw') was prevented.
+        // This must happen in case of an internal link.
+        expect(fakeMouseDownEvent.preventDefault).toHaveBeenCalled();
     });
 
     it('should emit a middle mouse button click on an internal link', () => {
@@ -135,21 +156,29 @@ describe('TextValueHtmlLinkDirective', () => {
         );
     });
 
-    it('should not react to clicking on an external link', () => {
+    it('should not emit on click on an external link', () => {
         expect(testHostComponent).toBeTruthy();
+        expect(testHostComponent.internalLinkClickedIri).toBeUndefined();
 
         const hostCompDe = testHostFixture.debugElement;
         const directiveDe = hostCompDe.query(
             By.directive(TextValueHtmlLinkDirective)
         );
 
+
         const externalLinkDe = directiveDe.query(By.css('a:not(.salsah-link)'));
 
-        externalLinkDe.nativeElement.click();
+        // left mouse event
+        externalLinkDe.nativeElement.dispatchEvent(
+            new MouseEvent('click', { bubbles: true, button: 0 })
+        );
 
         testHostFixture.detectChanges();
 
-        expect(testHostComponent.internalLinkClickedIri).toBeUndefined();
+        // as the link is external, the internalLinkClickedIri should not still be set to undefined
+        expect(testHostComponent.internalLinkClickedIri).toEqual(
+            undefined
+        );
     });
 
     it('should react to hovering over an internal link', () => {

--- a/apps/dsp-app/src/app/workspace/resource/directives/text-value-html-link.directive.ts
+++ b/apps/dsp-app/src/app/workspace/resource/directives/text-value-html-link.directive.ts
@@ -9,26 +9,62 @@ export class TextValueHtmlLinkDirective {
     @Output() internalLinkHovered = new EventEmitter<string>();
 
     /**
-     * react to a click event for an internal link.
+     * react to a click event for a link (left mouse button only). If it is an internal link, emit the event.
+     * If it is an external link, open it in a new tab.
      *
-     * @param targetElement the element that was clicked.
+     * @param event: The mouse event.
      */
-    @HostListener('mousedown', ['$event.target'])
-    onClick(targetElement) {
-        if (targetElement.nodeName.toLowerCase() !== 'a') {
-            return false; // only handle click events on links
-        }
+    @HostListener('click', ['$event'])
+    onClick(event: MouseEvent) {
+        const targetElement = event.target as HTMLAnchorElement;
         if (
-            targetElement.className
+            !targetElement ||
+            targetElement?.nodeName?.toLowerCase() !== 'a' ||
+            event.button === 2 || // right mouse button
+            event.button === 1 // middle mouse button
+        ) {
+            // only handle left mouse click events on links, all other events are ignored here
+            return;
+        }
+        if ( targetElement?.className
                 .toLowerCase()
                 .indexOf(Constants.SalsahLink) !== -1
-        ) {
+        ) { // if it is an internal link, override all behaviour, so also second mouse button clicks, hence the iris
+            // like "rdfh.ch/ ..." can not be dereferenced outside the app by a browser
             this.internalLinkClicked.emit(targetElement.href);
-            return false;
-        } else {
-            // open all other links as external links in a new tab
+            // prevent the default action for internal links
+            event.preventDefault();
+            return;
+
+        } else { // left mouse clicks on external links
+            // open in a new tab
             window.open(targetElement.href, '_blank');
-            return false;
+            event.preventDefault();
+        }
+    }
+
+    /**
+     * react to a mouse down event for a link (middle and second mouse button).
+     * For middle mouse and second mouse button clicks there is need to
+     * handle mousedown events instead of click events in order to override browsers default behaviour
+     * (open in new tab, context menu). The default behaviour is prevented for internal links.
+     *
+     * @param event: The mouse event.
+     */
+    @HostListener('mousedown', ['$event'])
+    onMouseDown(event: MouseEvent) {
+        const targetElement = event.target as HTMLAnchorElement;
+
+        if (!targetElement || targetElement.nodeName.toLowerCase() !== 'a') {
+            return; // only handle mouse events on links
+        }
+
+        // handle middle mouse and second mouse clicks here
+        if (event.button === 1 || event.button === 2) {
+            if (targetElement.className.toLowerCase().indexOf(Constants.SalsahLink) !== -1) {
+                this.internalLinkClicked.emit(targetElement.href);
+                event.preventDefault();
+            }
         }
     }
 


### PR DESCRIPTION
Further behaviour:
- second mouse and middle mouse clicks defaults for non internal links
- middle mouse and second mouse clicks on internal links disabled/overridden (open internally)

resolves DEV-2529
