### PR TITLE
refactor: Use dsp-ingest for file upload (DEV-2628)

### DIFF
--- a/apps/dsp-app/src/app/workspace/resource/representation/upload/upload.component.ts
+++ b/apps/dsp-app/src/app/workspace/resource/representation/upload/upload.component.ts
@@ -96,7 +96,6 @@ export class UploadComponent implements OnInit {
       } else {
         // show loading indicator only for files > 1MB
         this.isLoading = this.file.size > 1048576;
-        const sipiUrl = this._acs.dspIiifConfig.iiifUrl;
 
         this._store.select(ProjectsSelectors.currentProject).pipe(
           filter(v => v !== undefined),
@@ -105,7 +104,7 @@ export class UploadComponent implements OnInit {
         ).subscribe(
           (res: UploadedFile) => {
             // prepare thumbnail url to display something after upload
-              const thumbnailUri =  res.thumbnailUrl;
+            const thumbnailUri =  res.thumbnailUrl;
             switch (this.representation) {
               case 'stillImage':
                 this.thumbnailUrl = this._sanitizer.bypassSecurityTrustUrl( thumbnailUri);

--- a/apps/dsp-app/src/app/workspace/resource/representation/upload/upload.component.ts
+++ b/apps/dsp-app/src/app/workspace/resource/representation/upload/upload.component.ts
@@ -21,7 +21,7 @@ import { NotificationService } from '@dasch-swiss/vre/shared/app-notification';
 import { UploadedFile, UploadFileService } from '@dasch-swiss/vre/shared/app-resource-properties';
 import { Store } from '@ngxs/store';
 import { ProjectsSelectors } from '@dasch-swiss/vre/shared/app-state';
-import { filter, map, mergeMap } from 'rxjs/operators';
+import { filter, map, mergeMap, take } from 'rxjs/operators';
 import { AppConfigService } from '@dasch-swiss/vre/shared/app-config';
 
 // https://stackoverflow.com/questions/45661010/dynamic-nested-reactive-form-expressionchangedafterithasbeencheckederror
@@ -99,6 +99,7 @@ export class UploadComponent implements OnInit {
 
         this._store.select(ProjectsSelectors.currentProject).pipe(
           filter(v => v !== undefined),
+          take(1),
           map(prj=> prj.shortcode),
           mergeMap(sc => this._upload.upload(this.file, sc))
         ).subscribe(

--- a/apps/dsp-app/src/app/workspace/resource/representation/upload/upload.component.ts
+++ b/apps/dsp-app/src/app/workspace/resource/representation/upload/upload.component.ts
@@ -2,26 +2,26 @@ import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild }
 import { UntypedFormBuilder, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
 import {
-  CreateArchiveFileValue,
-  CreateAudioFileValue,
-  CreateDocumentFileValue,
-  CreateFileValue,
-  CreateMovingImageFileValue,
-  CreateStillImageFileValue,
-  CreateTextFileValue,
-  UpdateArchiveFileValue,
-  UpdateAudioFileValue,
-  UpdateDocumentFileValue,
-  UpdateFileValue,
-  UpdateMovingImageFileValue,
-  UpdateStillImageFileValue,
-  UpdateTextFileValue,
+    CreateArchiveFileValue,
+    CreateAudioFileValue,
+    CreateDocumentFileValue,
+    CreateFileValue,
+    CreateMovingImageFileValue,
+    CreateStillImageFileValue,
+    CreateTextFileValue,
+    UpdateArchiveFileValue,
+    UpdateAudioFileValue,
+    UpdateDocumentFileValue,
+    UpdateFileValue,
+    UpdateMovingImageFileValue,
+    UpdateStillImageFileValue,
+    UpdateTextFileValue,
 } from '@dasch-swiss/dsp-js';
 import { NotificationService } from '@dasch-swiss/vre/shared/app-notification';
 import { UploadedFile, UploadFileService } from '@dasch-swiss/vre/shared/app-resource-properties';
-import {Store} from "@ngxs/store";
-import {ProjectsSelectors} from "@dasch-swiss/vre/shared/app-state";
-import {filter, map, mergeMap} from "rxjs/operators";
+import { Store } from '@ngxs/store';
+import { ProjectsSelectors } from '@dasch-swiss/vre/shared/app-state';
+import { filter, map, mergeMap } from 'rxjs/operators';
 import { AppConfigService } from '@dasch-swiss/vre/shared/app-config';
 
 // https://stackoverflow.com/questions/45661010/dynamic-nested-reactive-form-expressionchangedafterithasbeencheckederror
@@ -104,14 +104,13 @@ export class UploadComponent implements OnInit {
         ).subscribe(
           (res: UploadedFile) => {
             // prepare thumbnail url to display something after upload
-            const thumbnailUri =  res.thumbnailUrl;
             switch (this.representation) {
               case 'stillImage':
-                this.thumbnailUrl = this._sanitizer.bypassSecurityTrustUrl( thumbnailUri);
+                this.thumbnailUrl = this._sanitizer.bypassSecurityTrustUrl( res.thumbnailUrl);
                 break;
 
               case 'document':
-                this.thumbnailUrl = thumbnailUri;
+                this.thumbnailUrl = res.baseUrl;
                 break;
 
               default:
@@ -119,7 +118,7 @@ export class UploadComponent implements OnInit {
                 break;
             }
 
-            this.fileControl.setValue(res.internalFilename);
+            this.fileControl.setValue(res);
             const fileValue = this.getNewValue();
 
             if (fileValue) {

--- a/apps/dsp-app/src/app/workspace/resource/representation/upload/upload.component.ts
+++ b/apps/dsp-app/src/app/workspace/resource/representation/upload/upload.component.ts
@@ -97,7 +97,7 @@ export class UploadComponent implements OnInit {
 
         this._store.select(ProjectsSelectors.currentProject).pipe(
           filter(v => v !== undefined),
-          map(p=> p.shortcode),
+          map(prj=> prj.shortcode),
           mergeMap(sc => this._upload.upload(this.file, sc))
         ).subscribe(
           (res: UploadedFileResponse) => {

--- a/apps/dsp-app/src/config/config.0845-test-server.json
+++ b/apps/dsp-app/src/config/config.0845-test-server.json
@@ -8,6 +8,7 @@
   "iiifHost": "iiif.0845-test-server.dasch.swiss",
   "iiifPort": 443,
   "iiifPath": "",
+  "ingestUrl": "https://ingest.0845-test-server.dasch.swiss",
   "geonameToken": "knora",
   "jsonWebToken": "",
   "logErrors": true,

--- a/apps/dsp-app/src/config/config.dev-server.json
+++ b/apps/dsp-app/src/config/config.dev-server.json
@@ -8,6 +8,7 @@
   "iiifHost": "iiif.dev.dasch.swiss",
   "iiifPort": 443,
   "iiifPath": "",
+  "ingestUrl": "https://ingest.dev.dasch.swiss",
   "geonameToken": "knora",
   "jsonWebToken": "",
   "logErrors": true,

--- a/apps/dsp-app/src/config/config.dev.json
+++ b/apps/dsp-app/src/config/config.dev.json
@@ -8,6 +8,7 @@
   "iiifHost": "0.0.0.0",
   "iiifPort": 1024,
   "iiifPath": "",
+  "ingestUrl": "http://0.0.0.0:3340",
   "geonameToken": "knora",
   "jsonWebToken": "",
   "logErrors": true,

--- a/apps/dsp-app/src/config/config.ls-test-server.json
+++ b/apps/dsp-app/src/config/config.ls-test-server.json
@@ -8,6 +8,7 @@
   "iiifHost": "iiif.ls-test-server.dasch.swiss",
   "iiifPort": 443,
   "iiifPath": "",
+  "ingestUrl": "https://ingest.ls-test-server.test.dasch.swiss",
   "geonameToken": "knora",
   "jsonWebToken": "",
   "logErrors": true,

--- a/apps/dsp-app/src/config/config.prod.json
+++ b/apps/dsp-app/src/config/config.prod.json
@@ -8,6 +8,7 @@
   "iiifHost": "0.0.0.0",
   "iiifPort": 1024,
   "iiifPath": "",
+  "ingestUrl": "http://0.0.0.0:3340",
   "geonameToken": "knora",
   "jsonWebToken": "",
   "logErrors": false,

--- a/apps/dsp-app/src/config/config.stage-server.json
+++ b/apps/dsp-app/src/config/config.stage-server.json
@@ -8,6 +8,7 @@
   "iiifHost": "iiif.stage.dasch.swiss",
   "iiifPort": 443,
   "iiifPath": "",
+  "ingestUrl": "https://ingest.stage.dasch.swiss",
   "geonameToken": "knora",
   "jsonWebToken": "",
   "logErrors": true,

--- a/apps/dsp-app/src/config/config.test-server.json
+++ b/apps/dsp-app/src/config/config.test-server.json
@@ -8,6 +8,7 @@
   "iiifHost": "iiif.test.dasch.swiss",
   "iiifPort": 443,
   "iiifPath": "",
+  "ingestUrl": "https://ingest.test.dasch.swiss",
   "geonameToken": "knora",
   "jsonWebToken": "",
   "logErrors": true,

--- a/libs/vre/shared/app-config/src/lib/app-config/app-config.service.spec.ts
+++ b/libs/vre/shared/app-config/src/lib/app-config/app-config.service.spec.ts
@@ -84,6 +84,7 @@ describe('AppConfigService with prod config', () => {
     iiifHost: '0.0.0.0',
     iiifPort: 1024,
     iiifPath: '',
+    ingestUrl: 'http://0.0.0.0:3340',
     jsonWebToken: 'mytoken',
     logErrors: true,
     geonameToken: 'geoname_token',
@@ -126,6 +127,7 @@ describe('AppConfigService with prod config', () => {
     expect(service.dspIiifConfig.iiifHost).toEqual('0.0.0.0');
     expect(service.dspIiifConfig.iiifPort).toEqual(1024);
     expect(service.dspIiifConfig.iiifPath).toEqual('');
+    expect(service.dspIngestConfig.url).toEqual('http://0.0.0.0:3340');
     expect(service.dspApiConfig.jsonWebToken).toEqual('mytoken');
     expect(service.dspApiConfig.logErrors).toEqual(true);
     expect(service.dspAppConfig.geonameToken).toEqual('geoname_token');

--- a/libs/vre/shared/app-config/src/lib/app-config/app-config.service.spec.ts
+++ b/libs/vre/shared/app-config/src/lib/app-config/app-config.service.spec.ts
@@ -21,6 +21,7 @@ describe('AppConfigService with dev config', () => {
     iiifHost: '0.0.0.0',
     iiifPort: 1024,
     iiifPath: 'mypath',
+    ingestUrl: 'http://0.0.0.0:3340',
     jsonWebToken: 'mytoken',
     logErrors: true,
     geonameToken: 'geoname_token',

--- a/libs/vre/shared/app-config/src/lib/app-config/app-config.service.ts
+++ b/libs/vre/shared/app-config/src/lib/app-config/app-config.service.ts
@@ -10,8 +10,8 @@ import { AppConfigToken } from './dsp-api-tokens';
 import { DspAppConfig } from './dsp-app-config';
 import { DspConfig } from './dsp-config';
 import { DspIiifConfig } from './dsp-iiif-config';
+import { DspIngestConfig } from './dsp-ingest-config';
 import { DspInstrumentationConfig, DspRollbarConfig } from './dsp-instrumentation-config';
-import {DspIngestConfig} from "./dsp-ingest-config";
 
 @Injectable({
   providedIn: 'root',

--- a/libs/vre/shared/app-config/src/lib/app-config/app-config.service.ts
+++ b/libs/vre/shared/app-config/src/lib/app-config/app-config.service.ts
@@ -10,6 +10,7 @@ import { AppConfigToken } from './dsp-api-tokens';
 import { DspAppConfig } from './dsp-app-config';
 import { DspConfig } from './dsp-config';
 import { DspIiifConfig } from './dsp-iiif-config';
+import { DspIngestConfig } from './dsp-iiif-config';
 import { DspInstrumentationConfig, DspRollbarConfig } from './dsp-instrumentation-config';
 
 @Injectable({
@@ -19,6 +20,7 @@ export class AppConfigService {
   private readonly _dspConfig: DspConfig;
   private readonly _dspApiConfig: KnoraApiConfig;
   private readonly _dspIiifConfig: DspIiifConfig;
+  private readonly _dspIngestConfig: DspIngestConfig;
   private readonly _dspAppConfig: DspAppConfig;
   private readonly _dspInstrumentationConfig: DspInstrumentationConfig;
 
@@ -59,6 +61,9 @@ export class AppConfigService {
     // init iiif configuration
     this._dspIiifConfig = new DspIiifConfig(c.iiifProtocol, c.iiifHost, c.iiifPort, c.iiifPath);
 
+    // init ingestconfiguration
+    this._dspIngestConfig = new DspIngestConfig(c.ingestUrl);
+
     // init dsp app extended configuration
     this._dspAppConfig = new DspAppConfig(c.geonameToken, c.iriBase);
 
@@ -79,6 +84,10 @@ export class AppConfigService {
 
   get dspIiifConfig(): DspIiifConfig {
     return this._dspIiifConfig;
+  }
+
+  get dspIngestConfig(): DspIngestConfig {
+    return this._dspIngestConfig;
   }
 
   get dspAppConfig(): DspAppConfig {

--- a/libs/vre/shared/app-config/src/lib/app-config/app-config.service.ts
+++ b/libs/vre/shared/app-config/src/lib/app-config/app-config.service.ts
@@ -10,8 +10,8 @@ import { AppConfigToken } from './dsp-api-tokens';
 import { DspAppConfig } from './dsp-app-config';
 import { DspConfig } from './dsp-config';
 import { DspIiifConfig } from './dsp-iiif-config';
-import { DspIngestConfig } from './dsp-iiif-config';
 import { DspInstrumentationConfig, DspRollbarConfig } from './dsp-instrumentation-config';
+import {DspIngestConfig} from "./dsp-ingest-config";
 
 @Injectable({
   providedIn: 'root',
@@ -61,7 +61,7 @@ export class AppConfigService {
     // init iiif configuration
     this._dspIiifConfig = new DspIiifConfig(c.iiifProtocol, c.iiifHost, c.iiifPort, c.iiifPath);
 
-    // init ingestconfiguration
+    // init ingest configuration
     this._dspIngestConfig = new DspIngestConfig(c.ingestUrl);
 
     // init dsp app extended configuration

--- a/libs/vre/shared/app-config/src/lib/app-config/app-config.ts
+++ b/libs/vre/shared/app-config/src/lib/app-config/app-config.ts
@@ -63,6 +63,7 @@ export const AppConfig = z.object({
   iiifHost: z.string().nonempty("required 'iiifHost' value missing in config"),
   iiifPort: IiifPort,
   iiifPath: z.string(),
+  ingestUrl: z.string(),
   geonameToken: z.string().nonempty("required 'geonameToken' value missing in config"),
   jsonWebToken: z.string(),
   iriBase: z.literal('http://rdfh.ch'),

--- a/libs/vre/shared/app-config/src/lib/app-config/dsp-ingest-config.ts
+++ b/libs/vre/shared/app-config/src/lib/app-config/dsp-ingest-config.ts
@@ -1,0 +1,14 @@
+/**
+ * configuration to instantiate the iiif url.
+ *
+ * @category Config
+ */
+export class DspIngestfConfig {
+  static readonly DSP_INGEST_URL = 'http://localhost:3340';
+
+  constructor(public dspIngestUrl: string) {}
+
+  get url(): string {
+    return this.dspIngestUrl;
+  }
+}

--- a/libs/vre/shared/app-config/src/lib/app-config/dsp-ingest-config.ts
+++ b/libs/vre/shared/app-config/src/lib/app-config/dsp-ingest-config.ts
@@ -4,16 +4,12 @@
  * @category Config
  */
 export class DspIngestConfig {
+  /**
+   * @param ingestUrl the url to the ingest service
+   */
+  constructor(public ingestUrl: string) {}
 
-    /**
-     * @param ingestUrl the url to the ingest service
-     */
-    constructor(
-        public ingestUrl: string,
-    ) {
-    }
-
-    get url(): string {
-        return this.ingestUrl;
-    }
+  get url(): string {
+    return this.ingestUrl;
+  }
 }

--- a/libs/vre/shared/app-config/src/lib/app-config/dsp-ingest-config.ts
+++ b/libs/vre/shared/app-config/src/lib/app-config/dsp-ingest-config.ts
@@ -1,14 +1,19 @@
 /**
- * configuration to instantiate the iiif url.
+ * configuration to instantiate the ingest url.
  *
  * @category Config
  */
-export class DspIngestfConfig {
-  static readonly DSP_INGEST_URL = 'http://localhost:3340';
+export class DspIngestConfig {
 
-  constructor(public dspIngestUrl: string) {}
+    /**
+     * @param ingestUrl the url to the ingest service
+     */
+    constructor(
+        public ingestUrl: string,
+    ) {
+    }
 
-  get url(): string {
-    return this.dspIngestUrl;
-  }
+    get url(): string {
+        return this.ingestUrl;
+    }
 }

--- a/libs/vre/shared/app-resource-properties/src/lib/upload-file.service.ts
+++ b/libs/vre/shared/app-resource-properties/src/lib/upload-file.service.ts
@@ -51,7 +51,7 @@ export class UploadFileService {
                 let baseUrl = `${this._acs.dspIiifConfig.iiifUrl}/${shortcode}/${res.internalFilename}`;
                 return {
                     internalFilename: res.internalFilename,
-                    thumbnailUrl: `${baseUrl}/full/256,/0/default.jpg`,
+                    thumbnailUrl: baseUrl + '/full/^256,/0/default.jpg',
                     baseUrl: baseUrl,
                 };
             }),

--- a/libs/vre/shared/app-resource-properties/src/lib/upload-file.service.ts
+++ b/libs/vre/shared/app-resource-properties/src/lib/upload-file.service.ts
@@ -1,8 +1,8 @@
-import { HttpClient, HttpParams } from '@angular/common/http';
-import { Injectable } from '@angular/core';
-import { AppConfigService } from '@dasch-swiss/vre/shared/app-config';
-import { AccessTokenService } from '@dasch-swiss/vre/shared/app-session';
-import { Observable } from 'rxjs';
+import {HttpClient, HttpParams} from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import {AppConfigService} from '@dasch-swiss/vre/shared/app-config';
+import {AccessTokenService} from '@dasch-swiss/vre/shared/app-session';
+import {Observable} from 'rxjs';
 
 export interface UploadedFile {
   fileType: string;
@@ -26,11 +26,11 @@ export class UploadFileService {
   ) {}
 
   /**
-   * uploads files to SIPI
-   * @param (file)
+   * uploads files to ingest server
+   * @param (file) The file to upload
+   * @param (shortcode) The project shortcode
    */
-  upload(file: FormData): Observable<UploadedFileResponse> {
-    const ingestUrl = `${this._acs.dspIngestConfig.url}`;
+  upload(file: FormData, shortcode: String): Observable<UploadedFileResponse> {
 
     const jwt = this._accessTokenService.getAccessToken()!;
     const params = new HttpParams().set('token', jwt);
@@ -41,6 +41,7 @@ export class UploadFileService {
       reportProgress: false,
       observe: 'body' as const,
     };
-    return this._http.post<UploadedFileResponse>(uploadUrl, file, options);
+    const url = `${this._acs.dspIngestConfig.url}/projects/${shortcode}/assets/ingest/${file.name}`;
+    return this._http.post<UploadedFileResponse>(url, file, options);
   }
 }

--- a/libs/vre/shared/app-resource-properties/src/lib/upload-file.service.ts
+++ b/libs/vre/shared/app-resource-properties/src/lib/upload-file.service.ts
@@ -1,4 +1,4 @@
-import {HttpClient, HttpParams} from '@angular/common/http';
+import {HttpClient, HttpHeaders, HttpParams} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {AppConfigService} from '@dasch-swiss/vre/shared/app-config';
 import {AccessTokenService} from '@dasch-swiss/vre/shared/app-session';
@@ -33,13 +33,16 @@ export class UploadFileService {
   upload(file: File, shortcode: string): Observable<UploadedFileResponse> {
 
     const jwt = this._accessTokenService.getAccessToken()!;
-    const params = new HttpParams().set('token', jwt);
+    const headers = new HttpHeaders({
+            'Content-Type': 'application/octet-stream}',
+            'Authorization': `Bearer ${jwt}`
+        },
+    );
 
-    // --> TODO in order to track the progress change below to true and 'events'
     const options = {
-      params,
       reportProgress: false,
       observe: 'body' as const,
+      headers : headers
     };
     const url = `${this._acs.dspIngestConfig.url}/projects/${shortcode}/assets/ingest/${file.name}`;
     return this._http.post<UploadedFileResponse>(url, file, options);

--- a/libs/vre/shared/app-resource-properties/src/lib/upload-file.service.ts
+++ b/libs/vre/shared/app-resource-properties/src/lib/upload-file.service.ts
@@ -30,7 +30,7 @@ export class UploadFileService {
    * @param (file) The file to upload
    * @param (shortcode) The project shortcode
    */
-  upload(file: File, shortcode: String): Observable<UploadedFileResponse> {
+  upload(file: File, shortcode: string): Observable<UploadedFileResponse> {
 
     const jwt = this._accessTokenService.getAccessToken()!;
     const params = new HttpParams().set('token', jwt);

--- a/libs/vre/shared/app-resource-properties/src/lib/upload-file.service.ts
+++ b/libs/vre/shared/app-resource-properties/src/lib/upload-file.service.ts
@@ -12,6 +12,7 @@ interface UploadedFileResponse {
 export interface UploadedFile {
     internalFilename: string;
     thumbnailUrl: string;
+    baseUrl: string;
 }
 
 @Injectable({
@@ -47,9 +48,11 @@ export class UploadFileService {
         const url = `${this._acs.dspIngestConfig.url}/projects/${shortcode}/assets/ingest/${file.name}`;
         return this._http.post<UploadedFileResponse>(url, file, options).pipe(
             map((res: UploadedFileResponse) => {
+                let baseUrl = `${this._acs.dspIiifConfig.iiifUrl}/${shortcode}/${res.internalFilename}`;
                 return {
                     internalFilename: res.internalFilename,
-                    thumbnailUrl: `${this._acs.dspIiifConfig.iiifUrl}/${shortcode}/${res.internalFilename}/full/256,/0/default.jpg`,
+                    thumbnailUrl: `${baseUrl}/full/256,/0/default.jpg`,
+                    baseUrl: baseUrl,
                 };
             }),
         );

--- a/libs/vre/shared/app-resource-properties/src/lib/upload-file.service.ts
+++ b/libs/vre/shared/app-resource-properties/src/lib/upload-file.service.ts
@@ -30,7 +30,7 @@ export class UploadFileService {
    * @param (file)
    */
   upload(file: FormData): Observable<UploadedFileResponse> {
-    const uploadUrl = `${this._acs.dspIiifConfig.iiifUrl}/upload`;
+    const ingestUrl = `${this._acs.dspIngestConfig.url}`;
 
     const jwt = this._accessTokenService.getAccessToken()!;
     const params = new HttpParams().set('token', jwt);

--- a/libs/vre/shared/app-resource-properties/src/lib/upload-file.service.ts
+++ b/libs/vre/shared/app-resource-properties/src/lib/upload-file.service.ts
@@ -6,55 +6,52 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 interface UploadedFileResponse {
-    internalFilename: string;
+  internalFilename: string;
 }
 
 export interface UploadedFile {
-    internalFilename: string;
-    thumbnailUrl: string;
-    baseUrl: string;
+  internalFilename: string;
+  thumbnailUrl: string;
+  baseUrl: string;
 }
 
 @Injectable({
-    providedIn: 'root',
+  providedIn: 'root',
 })
 export class UploadFileService {
-    constructor(
-        private readonly _acs: AppConfigService,
-        private readonly _http: HttpClient,
-        private readonly _accessTokenService: AccessTokenService,
-    ) {
-    }
+  constructor(
+    private readonly _acs: AppConfigService,
+    private readonly _http: HttpClient,
+    private readonly _accessTokenService: AccessTokenService
+  ) {}
 
-    /**
-     * uploads files to ingest server
-     * @param (file) The file to upload
-     * @param (shortcode) The project shortcode
-     */
-    upload(file: File, shortcode: string): Observable<UploadedFile> {
+  /**
+   * uploads files to ingest server
+   * @param (file) The file to upload
+   * @param (shortcode) The project shortcode
+   */
+  upload(file: File, shortcode: string): Observable<UploadedFile> {
+    const jwt = this._accessTokenService.getAccessToken()!;
+    const headers = new HttpHeaders({
+      'Content-Type': 'application/octet-stream}',
+      Authorization: `Bearer ${jwt}`,
+    });
 
-        const jwt = this._accessTokenService.getAccessToken()!;
-        const headers = new HttpHeaders({
-                'Content-Type': 'application/octet-stream}',
-                'Authorization': `Bearer ${jwt}`,
-            },
-        );
-
-        const options = {
-            reportProgress: false,
-            observe: 'body' as const,
-            headers: headers,
+    const options = {
+      reportProgress: false,
+      observe: 'body' as const,
+      headers,
+    };
+    const url = `${this._acs.dspIngestConfig.url}/projects/${shortcode}/assets/ingest/${file.name}`;
+    return this._http.post<UploadedFileResponse>(url, file, options).pipe(
+      map((res: UploadedFileResponse) => {
+        const baseUrl = `${this._acs.dspIiifConfig.iiifUrl}/${shortcode}/${res.internalFilename}`;
+        return {
+          internalFilename: res.internalFilename,
+          thumbnailUrl: `${baseUrl}/full/^256,/0/default.jpg`,
+          baseUrl,
         };
-        const url = `${this._acs.dspIngestConfig.url}/projects/${shortcode}/assets/ingest/${file.name}`;
-        return this._http.post<UploadedFileResponse>(url, file, options).pipe(
-            map((res: UploadedFileResponse) => {
-                let baseUrl = `${this._acs.dspIiifConfig.iiifUrl}/${shortcode}/${res.internalFilename}`;
-                return {
-                    internalFilename: res.internalFilename,
-                    thumbnailUrl: baseUrl + '/full/^256,/0/default.jpg',
-                    baseUrl: baseUrl,
-                };
-            }),
-        );
-    }
+      })
+    );
+  }
 }

--- a/libs/vre/shared/app-resource-properties/src/lib/upload-file.service.ts
+++ b/libs/vre/shared/app-resource-properties/src/lib/upload-file.service.ts
@@ -30,7 +30,7 @@ export class UploadFileService {
    * @param (file) The file to upload
    * @param (shortcode) The project shortcode
    */
-  upload(file: FormData, shortcode: String): Observable<UploadedFileResponse> {
+  upload(file: File, shortcode: String): Observable<UploadedFileResponse> {
 
     const jwt = this._accessTokenService.getAccessToken()!;
     const params = new HttpParams().set('token', jwt);

--- a/libs/vre/shared/app-resource-properties/src/lib/upload-file.service.ts
+++ b/libs/vre/shared/app-resource-properties/src/lib/upload-file.service.ts
@@ -1,50 +1,57 @@
-import {HttpClient, HttpHeaders, HttpParams} from '@angular/common/http';
-import {Injectable} from '@angular/core';
-import {AppConfigService} from '@dasch-swiss/vre/shared/app-config';
-import {AccessTokenService} from '@dasch-swiss/vre/shared/app-session';
-import {Observable} from 'rxjs';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { AppConfigService } from '@dasch-swiss/vre/shared/app-config';
+import { AccessTokenService } from '@dasch-swiss/vre/shared/app-session';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
-export interface UploadedFile {
-  fileType: string;
-  internalFilename: string;
-  originalFilename: string;
-  temporaryUrl: string;
+interface UploadedFileResponse {
+    internalFilename: string;
 }
 
-export interface UploadedFileResponse {
-  uploadedFiles: UploadedFile[];
+export interface UploadedFile {
+    internalFilename: string;
+    thumbnailUrl: string;
 }
 
 @Injectable({
-  providedIn: 'root',
+    providedIn: 'root',
 })
 export class UploadFileService {
-  constructor(
-    private readonly _acs: AppConfigService,
-    private readonly _http: HttpClient,
-    private readonly _accessTokenService: AccessTokenService
-  ) {}
+    constructor(
+        private readonly _acs: AppConfigService,
+        private readonly _http: HttpClient,
+        private readonly _accessTokenService: AccessTokenService,
+    ) {
+    }
 
-  /**
-   * uploads files to ingest server
-   * @param (file) The file to upload
-   * @param (shortcode) The project shortcode
-   */
-  upload(file: File, shortcode: string): Observable<UploadedFileResponse> {
+    /**
+     * uploads files to ingest server
+     * @param (file) The file to upload
+     * @param (shortcode) The project shortcode
+     */
+    upload(file: File, shortcode: string): Observable<UploadedFile> {
 
-    const jwt = this._accessTokenService.getAccessToken()!;
-    const headers = new HttpHeaders({
-            'Content-Type': 'application/octet-stream}',
-            'Authorization': `Bearer ${jwt}`
-        },
-    );
+        const jwt = this._accessTokenService.getAccessToken()!;
+        const headers = new HttpHeaders({
+                'Content-Type': 'application/octet-stream}',
+                'Authorization': `Bearer ${jwt}`,
+            },
+        );
 
-    const options = {
-      reportProgress: false,
-      observe: 'body' as const,
-      headers : headers
-    };
-    const url = `${this._acs.dspIngestConfig.url}/projects/${shortcode}/assets/ingest/${file.name}`;
-    return this._http.post<UploadedFileResponse>(url, file, options);
-  }
+        const options = {
+            reportProgress: false,
+            observe: 'body' as const,
+            headers: headers,
+        };
+        const url = `${this._acs.dspIngestConfig.url}/projects/${shortcode}/assets/ingest/${file.name}`;
+        return this._http.post<UploadedFileResponse>(url, file, options).pipe(
+            map((res: UploadedFileResponse) => {
+                return {
+                    internalFilename: res.internalFilename,
+                    thumbnailUrl: `${this._acs.dspIiifConfig.iiifUrl}/${shortcode}/${res.internalFilename}/full/256,/0/default.jpg`,
+                };
+            }),
+        );
+    }
 }

--- a/libs/vre/shared/app-resource-properties/src/lib/upload2.component.ts
+++ b/libs/vre/shared/app-resource-properties/src/lib/upload2.component.ts
@@ -131,7 +131,7 @@ export class Upload2Component implements ControlValueAccessor {
           this.previewUrl = this._sanitizer.bypassSecurityTrustUrl( res.thumbnailUrl );
           break;
         case Constants.HasDocumentFileValue:
-          this.previewUrl = res.thumbnailUrl;
+          this.previewUrl = res.baseUrl;
           break;
       }
 

--- a/libs/vre/shared/app-resource-properties/src/lib/upload2.component.ts
+++ b/libs/vre/shared/app-resource-properties/src/lib/upload2.component.ts
@@ -1,14 +1,14 @@
-import {ChangeDetectorRef, Component, ElementRef, Input, Self, ViewChild} from '@angular/core';
-import {ControlValueAccessor, NgControl} from '@angular/forms';
-import {DomSanitizer, SafeUrl} from '@angular/platform-browser';
-import {Constants} from '@dasch-swiss/dsp-js';
-import {NotificationService} from '@dasch-swiss/vre/shared/app-notification';
-import {FileRepresentationType} from './file-representation.type';
-import {fileValueMapping} from './file-value-mapping';
-import { UploadedFile, UploadFileService } from './upload-file.service';
-import {Store} from "@ngxs/store";
-import {ProjectsSelectors} from "@dasch-swiss/vre/shared/app-state";
+import { ChangeDetectorRef, Component, ElementRef, Input, Self, ViewChild } from '@angular/core';
+import { ControlValueAccessor, NgControl } from '@angular/forms';
+import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
+import { Constants } from '@dasch-swiss/dsp-js';
+import { NotificationService } from '@dasch-swiss/vre/shared/app-notification';
+import { ProjectsSelectors } from '@dasch-swiss/vre/shared/app-state';
+import { Store } from '@ngxs/store';
 import { filter, map, mergeMap, take } from 'rxjs/operators';
+import { FileRepresentationType } from './file-representation.type';
+import { fileValueMapping } from './file-value-mapping';
+import { UploadedFile, UploadFileService } from './upload-file.service';
 
 @Component({
   selector: 'app-upload-2',
@@ -121,29 +121,32 @@ export class Upload2Component implements ControlValueAccessor {
   }
 
   private _uploadFile(file: File): void {
-    this._store.select(ProjectsSelectors.currentProject).pipe(
+    this._store
+      .select(ProjectsSelectors.currentProject)
+      .pipe(
         filter(v => v !== undefined),
         take(1),
-        map(prj=> prj.shortcode),
+        map(prj => prj.shortcode),
         mergeMap(sc => this._upload.upload(file, sc))
-    ).subscribe((res: UploadedFile) => {
-      switch (this.representation) {
-        case Constants.HasStillImageFileValue:
-          this.previewUrl = this._sanitizer.bypassSecurityTrustUrl( res.thumbnailUrl );
-          break;
-        case Constants.HasDocumentFileValue:
-          this.previewUrl = res.baseUrl;
-          break;
-      }
+      )
+      .subscribe((res: UploadedFile) => {
+        switch (this.representation) {
+          case Constants.HasStillImageFileValue:
+            this.previewUrl = this._sanitizer.bypassSecurityTrustUrl(res.thumbnailUrl);
+            break;
+          case Constants.HasDocumentFileValue:
+            this.previewUrl = res.baseUrl;
+            break;
+        }
 
-      // eslint-disable-next-line new-cap
-      const fileResponse = new (fileValueMapping.get(this.representation)!.UploadClass)();
-      fileResponse.filename = res.internalFilename;
-      this.onChange(fileResponse);
-      this.onTouched();
+        // eslint-disable-next-line new-cap
+        const fileResponse = new (fileValueMapping.get(this.representation)!.UploadClass)();
+        fileResponse.filename = res.internalFilename;
+        this.onChange(fileResponse);
+        this.onTouched();
 
-      this._cdr.detectChanges();
-    });
+        this._cdr.detectChanges();
+      });
 
     this.fileInput.nativeElement.value = '';
   }

--- a/libs/vre/shared/app-resource-properties/src/lib/upload2.component.ts
+++ b/libs/vre/shared/app-resource-properties/src/lib/upload2.component.ts
@@ -8,7 +8,7 @@ import {fileValueMapping} from './file-value-mapping';
 import { UploadedFile, UploadFileService } from './upload-file.service';
 import {Store} from "@ngxs/store";
 import {ProjectsSelectors} from "@dasch-swiss/vre/shared/app-state";
-import {filter, map, mergeMap} from "rxjs/operators";
+import { filter, map, mergeMap, take } from 'rxjs/operators';
 
 @Component({
   selector: 'app-upload-2',
@@ -123,6 +123,7 @@ export class Upload2Component implements ControlValueAccessor {
   private _uploadFile(file: File): void {
     this._store.select(ProjectsSelectors.currentProject).pipe(
         filter(v => v !== undefined),
+        take(1),
         map(prj=> prj.shortcode),
         mergeMap(sc => this._upload.upload(file, sc))
     ).subscribe((res: UploadedFile) => {

--- a/libs/vre/shared/app-resource-properties/src/lib/upload2.component.ts
+++ b/libs/vre/shared/app-resource-properties/src/lib/upload2.component.ts
@@ -5,11 +5,10 @@ import {Constants} from '@dasch-swiss/dsp-js';
 import {NotificationService} from '@dasch-swiss/vre/shared/app-notification';
 import {FileRepresentationType} from './file-representation.type';
 import {fileValueMapping} from './file-value-mapping';
-import {UploadedFileResponse, UploadFileService} from './upload-file.service';
+import { UploadedFile, UploadFileService } from './upload-file.service';
 import {Store} from "@ngxs/store";
 import {ProjectsSelectors} from "@dasch-swiss/vre/shared/app-state";
 import {filter, map, mergeMap} from "rxjs/operators";
-import {project} from "effect/Layer";
 
 @Component({
   selector: 'app-upload-2',
@@ -126,21 +125,19 @@ export class Upload2Component implements ControlValueAccessor {
         filter(v => v !== undefined),
         map(prj=> prj.shortcode),
         mergeMap(sc => this._upload.upload(file, sc))
-    ).subscribe((res: UploadedFileResponse) => {
+    ).subscribe((res: UploadedFile) => {
       switch (this.representation) {
         case Constants.HasStillImageFileValue:
-          this.previewUrl = this._sanitizer.bypassSecurityTrustUrl(
-            `${res.uploadedFiles[0].temporaryUrl}/full/256,/0/default.jpg`
-          );
+          this.previewUrl = this._sanitizer.bypassSecurityTrustUrl( res.thumbnailUrl );
           break;
         case Constants.HasDocumentFileValue:
-          this.previewUrl = res.uploadedFiles[0].temporaryUrl;
+          this.previewUrl = res.thumbnailUrl;
           break;
       }
 
       // eslint-disable-next-line new-cap
       const fileResponse = new (fileValueMapping.get(this.representation)!.UploadClass)();
-      fileResponse.filename = res.uploadedFiles[0].internalFilename;
+      fileResponse.filename = res.internalFilename;
       this.onChange(fileResponse);
       this.onTouched();
 

--- a/libs/vre/shared/app-resource-properties/src/lib/upload2.component.ts
+++ b/libs/vre/shared/app-resource-properties/src/lib/upload2.component.ts
@@ -124,7 +124,7 @@ export class Upload2Component implements ControlValueAccessor {
   private _uploadFile(file: File): void {
     this._store.select(ProjectsSelectors.currentProject).pipe(
         filter(v => v !== undefined),
-        map(p=> p.shortcode),
+        map(prj=> prj.shortcode),
         mergeMap(sc => this._upload.upload(file, sc))
     ).subscribe((res: UploadedFileResponse) => {
       switch (this.representation) {

--- a/libs/vre/shared/app-resource-properties/src/lib/upload2.component.ts
+++ b/libs/vre/shared/app-resource-properties/src/lib/upload2.component.ts
@@ -122,13 +122,10 @@ export class Upload2Component implements ControlValueAccessor {
   }
 
   private _uploadFile(file: File): void {
-    const formData = new FormData();
-    formData.append(file.name, file);
-
-     this._store.select(ProjectsSelectors.currentProject).pipe(
+    this._store.select(ProjectsSelectors.currentProject).pipe(
         filter(v => v !== undefined),
         map(p=> p.shortcode),
-        mergeMap(s => this._upload.upload(formData, s))
+        mergeMap(sc => this._upload.upload(file, sc))
     ).subscribe((res: UploadedFileResponse) => {
       switch (this.representation) {
         case Constants.HasStillImageFileValue:

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@angular/platform-browser-dynamic": "^16.2.12",
     "@angular/router": "^16.2.12",
     "@ckeditor/ckeditor5-angular": "^5.2.0",
-    "@dasch-swiss/dsp-js": "^9.1.18",
+    "@dasch-swiss/dsp-js": "^10.0.0",
     "@dasch-swiss/jdnconvertiblecalendar": "^0.0.3",
     "@dasch-swiss/jdnconvertiblecalendardateadapter": "^1.1.1",
     "@grafana/faro-web-sdk": "^1.3.6",


### PR DESCRIPTION
- **add configuration for dsp-ingest server**
- **upload binaries to dsp-ingest instead of Sipi**

Needs https://github.com/dasch-swiss/dsp-js-lib/pull/639 to be merged, released and integrated for updating dsp-api resources correctly. 

For now I was able to test this locally by publish the dsp-js-lib for my machine using our built in [yalc](https://github.com/wclr/yalc) support:
```sh
> cd dsp-js-lib
> npm run yalc-publish
```

And import it into the app:
```sh
> cd dsp-das
> npm run yalc-add-lib
```