### PR TITLE
fix: highlighting image region after creating new one (#DEV-3700) 

### DIFF
--- a/libs/vre/shared/app-representations/src/lib/region.service.ts
+++ b/libs/vre/shared/app-representations/src/lib/region.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { ChangeDetectorRef, Injectable } from '@angular/core';
 import { ReadResourceSequence } from '@dasch-swiss/dsp-js';
 import { Common, DspResource } from '@dasch-swiss/vre/shared/app-common';
 import { IncomingService } from '@dasch-swiss/vre/shared/app-common-to-move';
@@ -27,7 +27,10 @@ export class RegionService {
   private _imageIsLoadedSubject = new BehaviorSubject(false);
   imageIsLoaded$ = this._imageIsLoadedSubject.asObservable();
 
-  constructor(private _incomingService: IncomingService) {}
+  constructor(
+    private _incomingService: IncomingService,
+    private _cd: ChangeDetectorRef
+  ) {}
 
   onInit(resource: DspResource) {
     this._resource = resource;
@@ -48,6 +51,7 @@ export class RegionService {
 
   highlightRegion(regionIri: string) {
     this._highlightRegion.next(regionIri);
+    this._cd.markForCheck();
   }
 
   imageIsLoaded() {

--- a/libs/vre/shared/app-representations/src/lib/region.service.ts
+++ b/libs/vre/shared/app-representations/src/lib/region.service.ts
@@ -46,6 +46,7 @@ export class RegionService {
       .pipe(take(1))
       .subscribe(res => {
         this._regionsSubject.next(res);
+        this._cd.markForCheck();
       });
   }
 

--- a/libs/vre/shared/app-representations/src/lib/still-image/still-image.component.ts
+++ b/libs/vre/shared/app-representations/src/lib/still-image/still-image.component.ts
@@ -306,8 +306,10 @@ export class StillImageComponent implements OnInit, OnChanges, OnDestroy {
         )
       )
       .subscribe(res => {
-        // this._viewer.destroy();
-        // this._setupViewer();
+        this._viewer.destroy(); // canvas-click event doesnt work anymore, is it viewer bug?
+        this._setupViewer();
+        this._loadImages();
+
         const regionId = (res as ReadResource).id;
         this._regionService.updateRegions();
         this._regionService.highlightRegion(regionId);

--- a/libs/vre/shared/app-resource-page/src/lib/resource-toolbar.component.ts
+++ b/libs/vre/shared/app-resource-page/src/lib/resource-toolbar.component.ts
@@ -258,11 +258,15 @@ export class ResourceToolbarComponent implements OnInit {
 
   private _onResourceDeleted(response: DeleteResourceResponse) {
     this._notification.openSnackBar(`${response.result}: ${this.resource.res.label}`);
+    if (this.resource.isRegion) {
+      this._regionService.updateRegions();
+      this._cd.markForCheck();
+      return;
+    }
+
     const ontologyIri = this._ontologyService.getOntologyIriFromRoute(this.attachedProject.shortcode);
     const classId = this.resource.res.entityInfo.classes[this.resource.res.type]?.id;
     this._store.dispatch(new LoadClassItemsCountAction(ontologyIri, classId));
     this._componentCommsService.emit(new EmitEvent(CommsEvents.resourceDeleted));
-    this._regionService.updateRegions();
-    this._cd.markForCheck();
   }
 }

--- a/libs/vre/shared/app-resource-page/src/lib/resource-toolbar.component.ts
+++ b/libs/vre/shared/app-resource-page/src/lib/resource-toolbar.component.ts
@@ -4,12 +4,13 @@ import { DeleteResourceResponse, PermissionUtil, ReadProject } from '@dasch-swis
 import { AdminProjectsApiService } from '@dasch-swiss/vre/open-api';
 import { DspResource, ResourceService } from '@dasch-swiss/vre/shared/app-common';
 import {
+  Events as CommsEvents,
   ComponentCommunicationEventService,
   EmitEvent,
-  Events as CommsEvents,
   OntologyService,
 } from '@dasch-swiss/vre/shared/app-helper-services';
 import { NotificationService } from '@dasch-swiss/vre/shared/app-notification';
+import { RegionService } from '@dasch-swiss/vre/shared/app-representations';
 import {
   DeleteResourceDialogComponent,
   DeleteResourceDialogProps,
@@ -170,7 +171,8 @@ export class ResourceToolbarComponent implements OnInit {
     private _dialog: MatDialog,
     private _adminProjectsApi: AdminProjectsApiService,
     private _store: Store,
-    private _viewContainerRef: ViewContainerRef
+    private _viewContainerRef: ViewContainerRef,
+    private _regionService: RegionService
   ) {}
 
   ngOnInit(): void {
@@ -260,6 +262,7 @@ export class ResourceToolbarComponent implements OnInit {
     const classId = this.resource.res.entityInfo.classes[this.resource.res.type]?.id;
     this._store.dispatch(new LoadClassItemsCountAction(ontologyIri, classId));
     this._componentCommsService.emit(new EmitEvent(CommsEvents.resourceDeleted));
+    this._regionService.updateRegions();
     this._cd.markForCheck();
   }
 }


### PR DESCRIPTION
fix: highlighting image region after creating new one (#DEV-3700)
prevents from loading resource list if removed resource is region