### PR TITLE
Feature/dev 3809 cannot select higher level list nodes anymore

### DIFF
--- a/libs/vre/shared/app-resource-properties/src/lib/value-components/nested-menu.component.ts
+++ b/libs/vre/shared/app-resource-properties/src/lib/value-components/nested-menu.component.ts
@@ -1,16 +1,11 @@
 import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
-import { MatMenu } from '@angular/material/menu';
+import { MatMenu, MatMenuTrigger } from '@angular/material/menu';
 import { ListNodeV2 } from '@dasch-swiss/dsp-js';
 
 @Component({
   selector: 'app-nested-menu',
   template: `
-    <mat-form-field
-      *ngIf="data.isRootNode"
-      #languageMenuTrigger="matMenuTrigger"
-      [matMenuTriggerFor]="menu"
-      data-cy="select-list-button"
-      style="width: 100%">
+    <mat-form-field *ngIf="data.isRootNode" [matMenuTriggerFor]="menu" data-cy="select-list-button" style="width: 100%">
       <mat-label>{{ selection ?? data.label }}</mat-label>
       <mat-select></mat-select>
     </mat-form-field>
@@ -19,7 +14,8 @@ import { ListNodeV2 } from '@dasch-swiss/dsp-js';
       mat-menu-item
       [matMenuTriggerFor]="menu"
       style="width: 100%"
-      (click)="selectMenuWithChildren(data)">
+      (click)="selectMenuWithChildren(data)"
+      (mouseenter)="openSubMenu()">
       {{ data.label }}
     </div>
     <mat-menu #menu="matMenu">
@@ -53,9 +49,14 @@ export class NestedMenuComponent {
   @Output() selectedNode = new EventEmitter<ListNodeV2>();
 
   @ViewChild(MatMenu) menu!: MatMenu;
+  @ViewChild(MatMenuTrigger) trigger!: MatMenuTrigger;
 
   selectMenuWithChildren(node: ListNodeV2) {
     this.menu.closed.emit('click');
     this.selectedNode.emit(node);
+  }
+
+  openSubMenu() {
+    this.trigger.openMenu();
   }
 }

--- a/libs/vre/shared/app-resource-properties/src/lib/value-components/nested-menu.component.ts
+++ b/libs/vre/shared/app-resource-properties/src/lib/value-components/nested-menu.component.ts
@@ -1,14 +1,25 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { MatMenu } from '@angular/material/menu';
 import { ListNodeV2 } from '@dasch-swiss/dsp-js';
 
 @Component({
   selector: 'app-nested-menu',
   template: `
-    <mat-form-field *ngIf="data.isRootNode" [matMenuTriggerFor]="menu" data-cy="select-list-button" style="width: 100%">
+    <mat-form-field
+      *ngIf="data.isRootNode"
+      #languageMenuTrigger="matMenuTrigger"
+      [matMenuTriggerFor]="menu"
+      data-cy="select-list-button"
+      style="width: 100%">
       <mat-label>{{ selection ?? data.label }}</mat-label>
       <mat-select></mat-select>
     </mat-form-field>
-    <div *ngIf="!data.isRootNode" mat-menu-item [matMenuTriggerFor]="menu" style="width: 100%">
+    <div
+      *ngIf="!data.isRootNode"
+      mat-menu-item
+      [matMenuTriggerFor]="menu"
+      style="width: 100%"
+      (click)="selectMenuWithChildren(data)">
       {{ data.label }}
     </div>
     <mat-menu #menu="matMenu">
@@ -40,4 +51,11 @@ export class NestedMenuComponent {
   @Input() data!: ListNodeV2;
   @Input() selection!: string;
   @Output() selectedNode = new EventEmitter<ListNodeV2>();
+
+  @ViewChild(MatMenu) menu!: MatMenu;
+
+  selectMenuWithChildren(node: ListNodeV2) {
+    this.menu.closed.emit('click');
+    this.selectedNode.emit(node);
+  }
 }


### PR DESCRIPTION
Now: you can select a menu-item that has children. It was not possible before