### PR TITLE
test: Migrate tests to k6/browser which left experimental stage, run cloud test in dedicated project

### DIFF
--- a/k6/Dockerfile.influxdb
+++ b/k6/Dockerfile.influxdb
@@ -1,6 +1,0 @@
-FROM influxdb:2.7.6-alpine
-
-# Create a k6 db
-RUN /bin/bash -c "influxd run & sleep 5 && influx -execute 'CREATE DATABASE k6' && kill %1 && sleep 5"
-
-CMD ["influxd"]

--- a/k6/docker-compose.yml
+++ b/k6/docker-compose.yml
@@ -1,10 +1,15 @@
 services:
   influxdb:
-    build:
-      context: .
-      dockerfile: Dockerfile.influxdb
+    image: influxdb:1.8-alpine
+    platform: linux/amd64
     ports:
       - '8086:8086'
+    environment:
+      - DOCKER_INFLUXDB_INIT_MODE=setup
+      - DOCKER_INFLUXDB_INIT_USERNAME=admin
+      - DOCKER_INFLUXDB_INIT_PASSWORD=admin
+      - DOCKER_INFLUXDB_INIT_ORG=dasch
+      - DOCKER_INFLUXDB_INIT_BUCKET=k6
   grafana:
     build:
       context: .

--- a/k6/justfile
+++ b/k6/justfile
@@ -29,7 +29,7 @@ grafana-up:
 
 # Stop grafana
 grafana-down:
-    docker-compose down
+    docker compose down
 
 # Run the test and export to local grafana
 run-grafana testToRun=testToRun:

--- a/k6/justfile
+++ b/k6/justfile
@@ -19,7 +19,7 @@ run testToRun=testToRun:
 
 # Run the test in k6 cloud
 run-cloud testToRun=testToRun:
-    APP_URL={{appUrl}} k6 cloud tests/{{testToRun}}.js
+    k6 cloud tests/{{testToRun}}.js
 
 # Start grafana
 grafana-up:

--- a/k6/options/options.js
+++ b/k6/options/options.js
@@ -37,6 +37,7 @@ export const defaultScenario = {
 
 export const defaultOptions = {
   cloud: {
+    projectID: 3704846,
     distribution: {
       distributionLabel1: { loadZone: 'amazon:de:frankfurt', percent: 100 },
     },

--- a/k6/pages/resource-page.js
+++ b/k6/pages/resource-page.js
@@ -1,7 +1,7 @@
 export class ResourcePage {
   constructor(page) {
     this.page = page;
-    this.rsourcelabel = page.locator('.resource-header > .resource-label > h4');
+    this.resourcelabel = page.locator('.resource-header > .resource-label > h4');
   }
   async goto() {
     await this.page.goto(__ENV.APP_URL + '/project/yTerZGyxjZVqFMNNKXCDPF/ontology/beol/basicLetter');

--- a/k6/pages/single-resource-page.js
+++ b/k6/pages/single-resource-page.js
@@ -1,0 +1,9 @@
+export class SingleResourcePage {
+  constructor(page) {
+    this.page = page;
+    this.resourcelabel = page.locator('.resource-header > .resource-label > h4');
+  }
+  async goto() {
+    await this.page.goto(__ENV.APP_URL + '/project/yTerZGyxjZVqFMNNKXCDPF/ontology/beol/basicLetter');
+  }
+}

--- a/k6/tests/first-page-load.js
+++ b/k6/tests/first-page-load.js
@@ -27,6 +27,6 @@ export default async function () {
     }
     await page.screenshot({ path: 'screenshots/homepage.png' });
   } finally {
-    page.close();
+    await page.close();
   }
 }

--- a/k6/tests/first-page-load.js
+++ b/k6/tests/first-page-load.js
@@ -1,4 +1,4 @@
-import { browser } from 'k6/experimental/browser';
+import { browser } from 'k6/browser';
 import { check } from 'k6';
 import { HomePage } from '../pages/home-page.js';
 import { defaultOptions } from '../options/options.js';
@@ -9,19 +9,23 @@ const errorCounter = new Counter('errors');
 export const options = defaultOptions;
 
 export default async function () {
-  const page = browser.newPage();
+  const context = await browser.newContext();
+  const page = await context.newPage();
   const homepage = new HomePage(page);
 
   try {
     await homepage.goto();
-    page.screenshot({ path: 'screenshots/homepage.png' });
+
+    await page.waitForNavigation();
+    const title = await page.title.textContent();
     let success = check(homepage, {
-      title: p => p.title.textContent() == 'Projects Overview',
+      title: title => title == 'Projects Overview',
     });
 
     if (!success) {
       errorCounter.add(1);
     }
+    await page.screenshot({ path: 'screenshots/homepage.png' });
   } finally {
     page.close();
   }

--- a/k6/tests/load-resource.js
+++ b/k6/tests/load-resource.js
@@ -18,13 +18,13 @@ export default async function () {
     await page.waitForNavigation();
     const resourceLabel = await page.resourcelabel.textContent();
     const success = check(homepage, {
-      resourcelabel: resourcelabel => resourcelabel == '1723-02-06_Scheuchzer_Johann_Jakob-Bernoulli_Johann_I',
+      resourceLabel: resourceLabel => resourceLabel == '1723-02-06_Scheuchzer_Johann_Jakob-Bernoulli_Johann_I',
     });
     if (!success) {
       errorCounter.add(1);
     }
     await page.screenshot({ path: 'screenshots/resource-page.png' });
   } finally {
-    page.close();
+    await page.close();
   }
 }

--- a/k6/tests/load-resource.js
+++ b/k6/tests/load-resource.js
@@ -1,4 +1,4 @@
-import { browser } from 'k6/experimental/browser';
+import { browser } from 'k6/browser';
 import { check } from 'k6';
 import { ResourcePage } from '../pages/resource-page.js';
 import { defaultOptions } from '../options/options.js';
@@ -8,18 +8,22 @@ export const options = defaultOptions;
 export const errorCounter = new Counter('errors');
 
 export default async function () {
-  const page = browser.newPage();
+  const context = await browser.newContext();
+  const page = await context.newPage();
   const homepage = new ResourcePage(page);
 
   try {
     await homepage.goto();
+
+    await page.waitForNavigation();
+    const resourceLabel = await page.resourcelabel.textContent();
     const success = check(homepage, {
-      resourcelabel: p => p.rsourcelabel.textContent() == '1723-02-06_Scheuchzer_Johann_Jakob-Bernoulli_Johann_I',
+      resourcelabel: resourcelabel => resourcelabel == '1723-02-06_Scheuchzer_Johann_Jakob-Bernoulli_Johann_I',
     });
     if (!success) {
       errorCounter.add(1);
     }
-    page.screenshot({ path: 'screenshots/resource-page.png' });
+    await page.screenshot({ path: 'screenshots/resource-page.png' });
   } finally {
     page.close();
   }

--- a/k6/tests/load-single-resource.js
+++ b/k6/tests/load-single-resource.js
@@ -1,0 +1,30 @@
+import { browser } from 'k6/browser';
+import { check } from 'k6';
+import { defaultOptions } from '../options/options.js';
+import { Counter } from 'k6/metrics';
+import { SingleResourcePage } from '../pages/single-resource-page.js';
+
+export const options = defaultOptions;
+export const errorCounter = new Counter('errors');
+
+export default async function () {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const homepage = new SingleResourcePage(page);
+
+  try {
+    await homepage.goto();
+
+    await page.waitForNavigation();
+    const resourceLabel = await page.resourcelabel.textContent();
+    const success = check(homepage, {
+      resourceLabel: resourceLabel => resourceLabel == 'transcription of M087-10-TN',
+    });
+    if (!success) {
+      errorCounter.add(1);
+    }
+    await page.screenshot({ path: 'screenshots/single-resource-page.png' });
+  } finally {
+    await page.close();
+  }
+}


### PR DESCRIPTION
- **feat**: Add dedicated project id for k6 cloud runs
- **feat**: Add test for a resource on a single page without databrowser
- **test**: Migrate tests to k6/browser 
- **fix**: Fixes local influxdb setup broken after last `influx-cli` release