### PR TITLE
chore: fix publishing to Docker Hub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,9 +155,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - run: |
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.ORG_GITHUB_PACKAGES_PAT }}" > ~/.npmrc
-          echo "registry=https://npm.pkg.github.com/dasch-swiss" >> ~/.npmrc
       - run: make docker-publish
 
   trigger-dev-deployment:

--- a/.github/workflows/publish-from-branch.yml
+++ b/.github/workflows/publish-from-branch.yml
@@ -17,7 +17,4 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - run: |
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.ORG_GITHUB_PACKAGES_PAT }}" > ~/.npmrc
-          echo "@dasch-swiss:registry=https://npm.pkg.github.com/dasch-swiss" >> ~/.npmrc
       - run: make docker-publish

--- a/package.json
+++ b/package.json
@@ -153,8 +153,5 @@
     "@nx/nx-darwin-x64": "16.5.3",
     "@nx/nx-linux-x64-gnu": "16.5.3",
     "@nx/nx-win32-x64-msvc": "16.5.3"
-  },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/dasch-swiss"
   }
 }


### PR DESCRIPTION
There are still some GH registry leftovers which break publishing to Docker Hub.
