### PR TITLE
chore: Remove Feature-Policy header

### DIFF
--- a/nginx/nginx-security-headers.conf
+++ b/nginx/nginx-security-headers.conf
@@ -3,5 +3,4 @@
 add_header X-Frame-Options "DENY" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Referrer-Policy "strict-origin" always;
-add_header Feature-Policy "microphone 'none'; geolocation 'none'; camera 'none'" always;
 add_header Permissions-Policy "microphone=(); geolocation=(); camera=()" always;


### PR DESCRIPTION
The Permissions-Policy header replaced the deprecated Feature-Policy header.

In the k6 test we have the following warning:

```
WARN[0001] Error with Feature-Policy header: Some features are specified in both Feature-Policy and Permissions-Policy header: microphone, geolocation, camera. Values defined in Permissions-Policy header will be used.  browser_source=security line_number=0 source=browser url=
```

resolves DEV-
