### PR TITLE
chore(dependabot): temporarily change updates interval and remove grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,15 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     commit-message:
       prefix: "chore"
       include: "scope"
-    groups:
-       frontend-dependencies:
-          applies-to: version-updates
-          patterns:
-            - "*"
+#    groups:
+#       frontend-dependencies:
+#          applies-to: version-updates
+#          patterns:
+#            - "*"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
To address problematic updates in separate PRs the grouping is turned off for now and it will be turned on again after the updates.