### PR TITLE
chore: improve Dependabot rules and grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,11 +12,22 @@ updates:
       prefix: "chore"
       include: "scope"
     groups:
+      angular-deps:
+        applies-to: version-updates
+        patterns:
+          - "@angular*"
+        update-types:
+          - "minor"
+          - "patch"
       nx-deps:
         applies-to: version-updates
         patterns:
           - "nx*"
-          - "@nrwl/*"
+          - "@nx*"
+          - "@nrwl*"
+        update-types:
+          - "minor"
+          - "patch"
 #    groups:
 #       frontend-dependencies:
 #          applies-to: version-updates
@@ -25,8 +36,11 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # we use github:dasch-swiss/ckeditor_custom_build#v2.0.0 and v2.0.1 seems to be broken
       - dependency-name: "ckeditor5-custom-build"
-      # we use  github:dasch-swiss/ckeditor_custom_build#v2.0.0 and v2.0.1 seems to be broken
+      # all nx and angular dependencies are for now handled manually, so for now are ignored
+      - dependency-name: "@angular/*"
+      - dependency-name: "nx*"
 
   - package-ecosystem: "docker"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       nx-deps:
         applies-to: version-updates
         patterns:
-          - "@nx/*"
+          - "nx*"
           - "@nrwl/*"
 #    groups:
 #       frontend-dependencies:

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,10 +130,10 @@
         "typescript": "~5.4.0"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "16.10.0",
-        "@nx/nx-darwin-x64": "16.10.0",
-        "@nx/nx-linux-x64-gnu": "16.10.0",
-        "@nx/nx-win32-x64-msvc": "16.10.0"
+        "@nx/nx-darwin-arm64": "19.0.8",
+        "@nx/nx-darwin-x64": "19.0.8",
+        "@nx/nx-linux-x64-gnu": "19.0.8",
+        "@nx/nx-win32-x64-msvc": "19.0.8"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -6770,9 +6770,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-arm64": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-16.10.0.tgz",
-      "integrity": "sha512-YF+MIpeuwFkyvM5OwgY/rTNRpgVAI/YiR0yTYCZR+X3AAvP775IVlusNgQ3oedTBRUzyRnI4Tknj1WniENFsvQ==",
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-19.0.8.tgz",
+      "integrity": "sha512-EuK/K6vAh2unCijDjDnIAqDSFIPNStbnbKml+W2JEsTkw36YinKhXbeATYTVXqUGgzMIAGMxylSJawvCYnaFOw==",
       "cpu": [
         "arm64"
       ],
@@ -6785,9 +6785,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-x64": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-16.10.0.tgz",
-      "integrity": "sha512-ypi6YxwXgb0kg2ixKXE3pwf5myVNUgWf1CsV5OzVccCM8NzheMO51KDXTDmEpXdzUsfT0AkO1sk5GZeCjhVONg==",
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-19.0.8.tgz",
+      "integrity": "sha512-6Xt2AgL5wG+cfmSTD5YPVchq+MfJSjD1OTOTZSVFLJ+U8H84UrmNwKnEj5wF0roRWeAV7ircnijaFqHHzlB35g==",
       "cpu": [
         "x64"
       ],
@@ -6860,9 +6860,9 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.10.0.tgz",
-      "integrity": "sha512-134PW/u/arNFAQKpqMJniC7irbChMPz+W+qtyKPAUXE0XFKPa7c1GtlI/wK2dvP9qJDZ6bKf0KtA0U/m2HMUOA==",
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.0.8.tgz",
+      "integrity": "sha512-mJkk7dQhjfmdl0hHFJRSFNNAqpy/uvnyIn8SRyI8HDHABAqmNVfA31EYUI+2SR27U/agHzBG9BIFqP9qLTUalw==",
       "cpu": [
         "x64"
       ],
@@ -6905,9 +6905,9 @@
       }
     },
     "node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.10.0.tgz",
-      "integrity": "sha512-5iV2NKZnzxJwZZ4DM5JVbRG/nkhAbzEskKaLBB82PmYGKzaDHuMHP1lcPoD/rtYMlowZgNA/RQndfKvPBPwmXA==",
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-19.0.8.tgz",
+      "integrity": "sha512-2f1KtC5fXHrI6HnvPZUIHyw4gjCQFm/Sd05CeSRbvWTAtgFRqrBn0olCCx76MDHxMjddnzzlwkAsC8WD2U6M8g==",
       "cpu": [
         "x64"
       ],
@@ -20382,66 +20382,6 @@
       "dev": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/nx/node_modules/@nx/nx-darwin-arm64": {
-      "version": "19.0.8",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-19.0.8.tgz",
-      "integrity": "sha512-EuK/K6vAh2unCijDjDnIAqDSFIPNStbnbKml+W2JEsTkw36YinKhXbeATYTVXqUGgzMIAGMxylSJawvCYnaFOw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/nx/node_modules/@nx/nx-darwin-x64": {
-      "version": "19.0.8",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-19.0.8.tgz",
-      "integrity": "sha512-6Xt2AgL5wG+cfmSTD5YPVchq+MfJSjD1OTOTZSVFLJ+U8H84UrmNwKnEj5wF0roRWeAV7ircnijaFqHHzlB35g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/nx/node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "19.0.8",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.0.8.tgz",
-      "integrity": "sha512-mJkk7dQhjfmdl0hHFJRSFNNAqpy/uvnyIn8SRyI8HDHABAqmNVfA31EYUI+2SR27U/agHzBG9BIFqP9qLTUalw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/nx/node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "19.0.8",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-19.0.8.tgz",
-      "integrity": "sha512-2f1KtC5fXHrI6HnvPZUIHyw4gjCQFm/Sd05CeSRbvWTAtgFRqrBn0olCCx76MDHxMjddnzzlwkAsC8WD2U6M8g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/nx/node_modules/jsonc-parser": {

--- a/package.json
+++ b/package.json
@@ -155,9 +155,9 @@
     "typescript": "~5.4.0"
   },
   "optionalDependencies": {
-    "@nx/nx-darwin-arm64": "16.10.0",
-    "@nx/nx-darwin-x64": "16.10.0",
-    "@nx/nx-linux-x64-gnu": "16.10.0",
-    "@nx/nx-win32-x64-msvc": "16.10.0"
+    "@nx/nx-darwin-arm64": "19.0.8",
+    "@nx/nx-darwin-x64": "19.0.8",
+    "@nx/nx-linux-x64-gnu": "19.0.8",
+    "@nx/nx-win32-x64-msvc": "19.0.8"
   }
 }


### PR DESCRIPTION
This PR includes:
- improve nx-deps pattern
- bump and install optional nx-deps
- add angular group and ignore rule for angular and nx dependencies group
