### PR TITLE
fix: rollback ckeditor version to not include footnotes plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@sentry/cli": "^2.41.1",
         "angular-imask": "^7.5.0",
         "angular-split": "^14.0.0",
-        "ckeditor5-custom-build": "github:dasch-swiss/ckeditor_custom_build#v2.1.4",
+        "ckeditor5-custom-build": "github:dasch-swiss/ckeditor_custom_build#v2.0.0",
         "core-js": "^3.40.0",
         "effect": "^2.0.0-next.21",
         "immer": "^10.0.3",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@sentry/cli": "^2.41.1",
     "angular-imask": "^7.5.0",
     "angular-split": "^14.0.0",
-    "ckeditor5-custom-build": "github:dasch-swiss/ckeditor_custom_build#v2.1.4",
+    "ckeditor5-custom-build": "github:dasch-swiss/ckeditor_custom_build#v2.0.0",
     "core-js": "^3.40.0",
     "effect": "^2.0.0-next.21",
     "immer": "^10.0.3",


### PR DESCRIPTION
resolves DEV-
