### PR TITLE
chore: add environments list excluded from tracking by Sentry

### DIFF
--- a/apps/dsp-app/src/main.ts
+++ b/apps/dsp-app/src/main.ts
@@ -6,7 +6,22 @@ import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
 function initSentry(environmentName: string) {
-  if (environmentName === 'local-dev') return;
+  const serverNamesListToExcludeFromSentry = [
+    'demo',
+    'dev',
+    'dev-02',
+    'dev-03',
+    'dev-04',
+    'dev-05',
+    'dev-06',
+    'dev-server',
+    'local-dev',
+    'ls-test',
+    'perf-01',
+    'test-rdu',
+  ];
+
+  if (serverNamesListToExcludeFromSentry.includes(environmentName)) return;
 
   Sentry.init({
     dsn: 'https://20bfc69ec9e457239886c1128cc17928@o4506122165747712.ingest.us.sentry.io/4506122171252736',


### PR DESCRIPTION
The list of excluded servers should reduce Sentry quota. 