### PR TITLE
style: change align-items values from start to flex-start

### DIFF
--- a/libs/vre/resource-editor/resource-editor/src/lib/resource-header.component.ts
+++ b/libs/vre/resource-editor/resource-editor/src/lib/resource-header.component.ts
@@ -55,7 +55,7 @@ import { filter } from 'rxjs/operators';
         display: flex;
         box-sizing: border-box;
         flex-direction: row;
-        align-items: start;
+        align-items: flex-start;
         justify-content: space-between;
 
         h3.label-info {

--- a/libs/vre/ui/date-picker/src/lib/app-date-picker/app-date-picker.component.scss
+++ b/libs/vre/ui/date-picker/src/lib/app-date-picker/app-date-picker.component.scss
@@ -18,7 +18,7 @@
   &.calendar-selector,
   &.month-year-selector {
     display: inline-flex;
-    align-items: start;
+    align-items: flex-start;
   }
 
   &.calendar-selector {


### PR DESCRIPTION
Removes below e2e tests warning:
<img width="1082" alt="image" src="https://github.com/user-attachments/assets/cd1bfa4b-3c40-49fe-8d69-ab554cd29c89" />
