### PR TITLE
edit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  push:
+  pull_request:
 
 env:
   # use the read-write access token so that build cache in nx-cloud can be updated


### PR DESCRIPTION
Currently, a PR opened from a fork cannot be merged, because the mandatory checks aren't triggered (see https://github.com/dasch-swiss/dsp-das/pull/2229). This is due to the wrong triggering conditions.

`on: pull_request` makes sure that the tests are triggered if a PR is opened, synchronized, or reopened. We had the same problem in DSP-TOOLS, where it was resolved by the same fix, see https://github.com/dasch-swiss/dsp-tools/pull/1608.